### PR TITLE
Add target_bundle

### DIFF
--- a/thunder_base_set.json
+++ b/thunder_base_set.json
@@ -655,7 +655,9 @@
                         "translatable": true,
                         "cardinality": -1,
                         "target_type": "taxonomy_term",
-                        "target_bundles": [],
+                        "target_bundles": [
+                            "bundle_5"
+                        ],
                         "histogram": {
                             "1": 326,
                             "2": 678,


### PR DESCRIPTION
Entity reference fields which use a view for providing selection do not have target bundles set.

Fix is for node bundle_0 field_22